### PR TITLE
Extract file name/package logic and add unit tests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { basename } from 'path';
+import { toggleFileName, extractPackage } from './logic';
 
 export function activate(context: vscode.ExtensionContext) {
   const disposable = vscode.commands.registerCommand('vscode-quick-junit.toggleTestFile', async () => {
@@ -10,12 +11,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const currentFileName = basename(editor.document.uri.fsPath);
-    let targetFileName = null;
-    if (currentFileName.endsWith('Test.java')) {
-      targetFileName = currentFileName.replace(/Test\.java$/, '.java');
-    } else {
-      targetFileName = currentFileName.replace(/\.java$/, 'Test.java');
-    }
+    const targetFileName = toggleFileName(currentFileName);
 
     const files = await vscode.workspace.findFiles(`**/${targetFileName}`);
     if (files.length === 0) {
@@ -28,11 +24,11 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    const currentPackage = getPackage(editor.document);
+    const currentPackage = extractPackage(editor.document.getText());
     for (const file of files) {
       const document = await vscode.workspace.openTextDocument(file);
-      const candidateFilePackage = getPackage(document);
-      if (currentPackage === candidateFilePackage) {
+      const candidatePackage = extractPackage(document.getText());
+      if (currentPackage === candidatePackage) {
         await vscode.window.showTextDocument(document);
         return;
       }
@@ -40,12 +36,6 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(disposable);
-}
-
-function getPackage(document: vscode.TextDocument): string{
-  const src = document.getText();
-  const match = src.match(/package\s+([a-z.]+)\s*;/);
-  return match ? match[1] : '';
 }
 
 export function deactivate() {}

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -1,0 +1,11 @@
+export function toggleFileName(fileName: string): string {
+  if (fileName.endsWith('Test.java')) {
+    return fileName.replace(/Test\.java$/, '.java');
+  }
+  return fileName.replace(/\.java$/, 'Test.java');
+}
+
+export function extractPackage(source: string): string {
+  const match = source.match(/package\s+([a-z.]+)\s*;/);
+  return match ? match[1] : '';
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,15 +1,28 @@
 import * as assert from 'assert';
+import { toggleFileName, extractPackage } from '../logic';
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+suite('toggleFileName', () => {
+	test('converts a production file name to its test file name', () => {
+		assert.strictEqual(toggleFileName('Foo.java'), 'FooTest.java');
+	});
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+	test('converts a test file name back to its production file name', () => {
+		assert.strictEqual(toggleFileName('FooTest.java'), 'Foo.java');
+	});
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	test('leaves non-.java file names unchanged', () => {
+		assert.strictEqual(toggleFileName('Foo.txt'), 'Foo.txt');
+	});
+});
+
+suite('extractPackage', () => {
+	test('extracts the package name from a source file', () => {
+		const source = 'package com.example.app;\n\npublic class Foo {}\n';
+		assert.strictEqual(extractPackage(source), 'com.example.app');
+	});
+
+	test('returns an empty string when there is no package declaration', () => {
+		const source = 'public class Foo {}\n';
+		assert.strictEqual(extractPackage(source), '');
 	});
 });


### PR DESCRIPTION
## Summary
- The command's file-name conversion and package extraction logic was inline in the `registerCommand` callback, and `extension.test.ts` only had the scaffold sample test, so none of the extension's actual behavior was verified.
- Extracted the pure logic into `src/logic.ts` (`toggleFileName`, `extractPackage`) and updated `src/extension.ts` to use it.
- Replaced the scaffold sample test with unit tests covering both functions.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (5 passing)