### PR TITLE
Extract command handler out of the registerCommand callback

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,40 +1,8 @@
 import * as vscode from 'vscode';
-import { basename } from 'path';
-import { toggleFileName, extractPackage } from './logic';
+import { toggleTestFile } from './toggleTestFile';
 
 export function activate(context: vscode.ExtensionContext) {
-  const disposable = vscode.commands.registerCommand('vscode-quick-junit.toggleTestFile', async () => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      vscode.window.showInformationMessage('No file is currently open.');
-      return;
-    }
-
-    const currentFileName = basename(editor.document.uri.fsPath);
-    const targetFileName = toggleFileName(currentFileName);
-
-    const files = await vscode.workspace.findFiles(`**/${targetFileName}`);
-    if (files.length === 0) {
-      return;
-    }
-
-    if (files.length === 1) {
-      const document = await vscode.workspace.openTextDocument(files[0]);
-      await vscode.window.showTextDocument(document);
-      return;
-    }
-
-    const currentPackage = extractPackage(editor.document.getText());
-    for (const file of files) {
-      const document = await vscode.workspace.openTextDocument(file);
-      const candidatePackage = extractPackage(document.getText());
-      if (currentPackage === candidatePackage) {
-        await vscode.window.showTextDocument(document);
-        return;
-      }
-    }
-  });
-
+  const disposable = vscode.commands.registerCommand('vscode-quick-junit.toggleTestFile', toggleTestFile);
   context.subscriptions.push(disposable);
 }
 

--- a/src/toggleTestFile.ts
+++ b/src/toggleTestFile.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import { basename } from 'path';
+import { toggleFileName, extractPackage } from './logic';
+
+export async function toggleTestFile(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showInformationMessage('No file is currently open.');
+    return;
+  }
+
+  const currentFileName = basename(editor.document.uri.fsPath);
+  const targetFileName = toggleFileName(currentFileName);
+
+  const files = await vscode.workspace.findFiles(`**/${targetFileName}`);
+  if (files.length === 0) {
+    return;
+  }
+
+  if (files.length === 1) {
+    const document = await vscode.workspace.openTextDocument(files[0]);
+    await vscode.window.showTextDocument(document);
+    return;
+  }
+
+  const currentPackage = extractPackage(editor.document.getText());
+  for (const file of files) {
+    const document = await vscode.workspace.openTextDocument(file);
+    const candidatePackage = extractPackage(document.getText());
+    if (currentPackage === candidatePackage) {
+      await vscode.window.showTextDocument(document);
+      return;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- All the command's control flow (file lookup, package matching, editor navigation) lived in an anonymous callback inside `registerCommand`, so the handler itself couldn't be unit tested — only the pure helpers extracted in #25 could be.
- Moved the handler into a named `toggleTestFile()` function in `src/toggleTestFile.ts`. `activate()` in `src/extension.ts` is now just wiring: register the command and push the disposable.

## Test plan
- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm test` (5 passing)